### PR TITLE
MVPリリース申請

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,7 @@
 <div class="container py-5">
+  <%# エラーメッセージを画面幅いっぱいに表示 %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
   <div class="row justify-content-center">
     <div class="col-12 col-md-8 col-lg-5">
       <div class="card shadow">
@@ -6,7 +9,6 @@
           <h2 class="card-title text-center mb-4">新規登録</h2>
 
           <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-            <%= render "devise/shared/error_messages", resource: resource %>
 
             <div class="mb-3">
               <%= f.label :username, "ユーザー名", class: "form-label" %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,15 +1,8 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
-    <ul>
-      <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
+  <div class="alert alert-danger alert-dismissible fade show" role="alert" data-turbo-cache="false">
+    <% resource.errors.full_messages.each do |message| %>
+      <span><%= message %></span><br>
+    <% end %>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   </div>
 <% end %>

--- a/app/views/shrine_records/_form.html.erb
+++ b/app/views/shrine_records/_form.html.erb
@@ -1,18 +1,5 @@
 <%# 参拝記録フォーム（新規作成・編集共通） %>
 <%= form_with model: shrine_record, local: true do |f| %>
-  <%# エラーメッセージの表示 %>
-  <% if shrine_record.errors.any? %>
-    <div class="alert alert-danger">
-      <h5 class="alert-heading">
-        <%= shrine_record.errors.count %>件のエラーがあります
-      </h5>
-      <ul class="mb-0">
-        <% shrine_record.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
 
   <%# 神社名（必須） %>
   <div class="mb-3">

--- a/app/views/shrine_records/edit.html.erb
+++ b/app/views/shrine_records/edit.html.erb
@@ -1,5 +1,15 @@
 <%# 参拝記録 編集画面 %>
 <div class="container py-4">
+  <%# エラーメッセージをカードの外に表示 %>
+  <% if @shrine_record.errors.any? %>
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+      <% @shrine_record.errors.full_messages.each do |message| %>
+        <span><%= message %></span><br>
+      <% end %>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+  <% end %>
+
   <div class="row justify-content-center">
     <div class="col-md-8">
       <%# フォームカード %>

--- a/app/views/shrine_records/new.html.erb
+++ b/app/views/shrine_records/new.html.erb
@@ -1,5 +1,15 @@
 <%# 参拝記録 新規作成画面 %>
 <div class="container py-4">
+  <%# エラーメッセージをカードの外に表示 %>
+  <% if @shrine_record.errors.any? %>
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+      <% @shrine_record.errors.full_messages.each do |message| %>
+        <span><%= message %></span><br>
+      <% end %>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+  <% end %>
+
   <div class="row justify-content-center">
     <div class="col-md-8">
       <%# フォームカード %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,35 +11,35 @@ ja:
         long: "$Y年%m月%d日(%a) %H:%M"
         short: "$m月$d日 %H:%M"
     
-    # ActibeRecordのエラーメッセージ
-    activerecord:
-      errors:
-        messages:
-          blank: "を入力してください"
-          taken: "はすでに使用されています"
-          too-short: "は%{count}文字以上で入力してください"
-          too-long: "は%{count}文字以下で入力してください"
-          invalid: "は不正な値です"
-          confirmation: "と一致しません"
-      # モデル名の日本語化
-      models:
-        user: "ユーザー"
-      # 属性名の日本語化
-      attributes:
-        user:
-          username: "ユーザー名"
-          email: "メールアドレス"
-          password: "パスワード"
-          password_confirmation: "パスワード（確認用）"
-    
-    # Deviseのメッセージ
-    devise:
-      registrations:
-        signed_up: "アカウント登録が完了しました。"
-        updated: "アカウント情報を変更しました。"
-      sessions:
-        signed_in: "ログインしました。"
-        signed_out: "ログアウトしました。"
-      failure:
-        invalid: "メールアドレスまたはパスワードが違います。"
-        unauthenticated: "ログインしてください。"
+  # ActibeRecordのエラーメッセージ
+  activerecord:
+    errors:
+      messages:
+        blank: "を入力してください"
+        taken: "はすでに使用されています"
+        too_short: "は%{count}文字以上で入力してください"
+        too_long: "は%{count}文字以下で入力してください"
+        invalid: "は不正な値です"
+        confirmation: "と一致しません"
+    # モデル名の日本語化
+    models:
+      user: "ユーザー"
+    # 属性名の日本語化
+    attributes:
+      user:
+        username: "ユーザー名"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認用）"
+  
+  # Deviseのメッセージ
+  devise:
+    registrations:
+      signed_up: "アカウント登録が完了しました。"
+      updated: "アカウント情報を変更しました。"
+    sessions:
+      signed_in: "ログインしました。"
+      signed_out: "ログアウトしました。"
+    failure:
+      invalid: "メールアドレスまたはパスワードが違います。"
+      unauthenticated: "ログインしてください。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,16 +2,16 @@ ja:
   # 日付・時刻のフォーマット
   date:
     formats:
-      default: "$Y年%m月%d日"
-      long: "$Y年%m月%d日(%a)"
-      short: "$m月$d日"
-    time:
-      formats:
-        default: "$Y年%m月%d日 %H:%M"
-        long: "$Y年%m月%d日(%a) %H:%M"
-        short: "$m月$d日 %H:%M"
-    
-  # ActibeRecordのエラーメッセージ
+      default: "%Y年%m月%d日"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m月%d日"
+  time:
+    formats:
+      default: "%Y年%m月%d日 %H:%M"
+      long: "%Y年%m月%d日(%a) %H:%M"
+      short: "%m月%d日 %H:%M"
+
+  # ActiveRecordのエラーメッセージ
   activerecord:
     errors:
       messages:
@@ -24,6 +24,7 @@ ja:
     # モデル名の日本語化
     models:
       user: "ユーザー"
+      shrine_record: "参拝記録"
     # 属性名の日本語化
     attributes:
       user:
@@ -31,7 +32,17 @@ ja:
         email: "メールアドレス"
         password: "パスワード"
         password_confirmation: "パスワード（確認用）"
-  
+      shrine_record:
+        shrine_name: "神社名"
+        deity: "御祭神"
+        benefit: "御利益"
+        visited_on: "参拝日"
+        wish: "お願いごと"
+        memo: "メモ"
+        latitude: "緯度"
+        longitude: "経度"
+        photo: "写真"
+
   # Deviseのメッセージ
   devise:
     registrations:


### PR DESCRIPTION
## 各種情報

サービスの概要とMVPで検証する事柄：
参拝した神社の写真・メモ・位置情報・参拝日などを一元管理できる「デジタル参拝記録」サービスです。
神社巡りの記録を簡単に保存・整理し、いつでも振り返れる参拝記録を提供します。

サービス名： 参拝記録アプリ

サービスURL： https://shrine-record-app.onrender.com


## READMEレビュー時にMVPリリース時点で実装予定だった機能

- [x] ユーザー登録（メール・パスワード・ユーザーネーム）
- [x] ログイン / ログアウト
- [x] 参拝記録の登録
  - [x] 神社名
  - [x] 御祭神
  - [x] 参拝日
  - [x] お願いごと
  - [x] メモ
  - [x] 写真アップロード（カメラ撮影・ライブラリ選択対応 / ActiveStorage）
  - [x] 位置情報（緯度・経度）
- [x] 参拝記録一覧表示（降順）
- [x] 参拝記録詳細表示
- [x] 参拝記録の編集・削除

## READMEレビュー時から変更した機能
- [x] 参拝記録の登録
  - [x] 御利益(追加)

## サービスイメージがわかるようなスクリーンショット等
[![Image from Gyazo](https://i.gyazo.com/f6624dcb0e11d0d52340ba27afaaeb22.png)](https://gyazo.com/f6624dcb0e11d0d52340ba27afaaeb22)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves validation UX and i18n consistency.
> 
> - Uses a Bootstrap `alert-dismissible` for validation errors via `devise/shared/_error_messages`, and shows errors outside form cards in `shrine_records/new` and `edit`
> - Removes the inline error block from `shrine_records/_form` to prevent duplication
> - Updates `config/locales/ja.yml`: fixes date/time format strings, adds `shrine_record` model/attribute translations, and normalizes ActiveRecord/Devise messages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aac285593330e52edb4306e4d1ebeb58402f436d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->